### PR TITLE
Avoid warning for clone of field for running tests

### DIFF
--- a/django_currentuser/db/models/fields.py
+++ b/django_currentuser/db/models/fields.py
@@ -1,3 +1,4 @@
+import sys
 import warnings
 
 from django.db import models
@@ -13,7 +14,9 @@ class CurrentUserField(models.ForeignKey):
         'as default value sets the current logged in user if available')
 
     def __init__(self, *a, **kw):
-        if a or set(kw).intersection({"default", "null", "to"}):
+        test_arg = sys.argv[2:3]
+        is_test_run = test_arg and 'test' in test_arg.pop()
+        if (a or set(kw).intersection({"default", "null", "to"})) and not is_test_run:
             warnings.warn(self.warning)
         if "on_delete" not in kw:
             kw["on_delete"] = models.CASCADE


### PR DESCRIPTION
Django clones fields (leads to re-init with forbidden kwargs) when running tests and that triggers the warning for no good reason. Not a perfect solution but at that scope it seems there is nothing else to determine a 2nd init.