### PR TITLE
Fixed compatibility issue.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,9 +31,7 @@ setup(
     ],
     include_package_data=True,
     install_requires=[
-        'Django>=1.11.17,<2.0',
-        'Django>=2.1.8,<2.2;python_version>"3.4"',
-        'Django>=2.2.1,<2.3;python_version>"3.4"',
+        'Django>=1.11.17,<2.3;python_version>"3.4"',
     ],
     license="BSD",
     zip_safe=False,


### PR DESCRIPTION
On `pip install django-currentuser` we get this stacktrace:

```python
ERROR: django-currentuser 0.4.1 has requirement Django<2.0,>=1.11.17,
but you'll have django 2.2.2 which is
incompatible.
ERROR: django-currentuser 0.4.1 has requirement Django<2.2,>=2.1.8;
python_version > "3.4", but you'll have
django 2.2.2 which is incompatible.
```
Also the TravisCI builds were failing.