### PR TITLE
Unset current user after request is processed

### DIFF
--- a/django_currentuser/middleware.py
+++ b/django_currentuser/middleware.py
@@ -32,6 +32,7 @@ class ThreadLocalUserMiddleware(object):
         # request.user (non-data descriptor)
         _do_set_current_user(lambda self: getattr(request, 'user', None))
         response = self.get_response(request)
+        _do_set_current_user(lambda self: None)
         return response
 
 


### PR DESCRIPTION
### Problem
When using `get_current_authenticated_user` outside of request context (middleware not applied) the thread variable still contains  instance of a last user that performed request (which might not exist anymore)

#### Occurences
1. In tests
2. In commands

#### Related issues
- [tearDown problems in unit tests? #14 ](https://github.com/PaesslerAG/django-currentuser/issues/14)